### PR TITLE
Process multiple samples supplied in a manifest

### DIFF
--- a/src/toil_scripts/adam_gatk_pipeline/align_and_call.py
+++ b/src/toil_scripts/adam_gatk_pipeline/align_and_call.py
@@ -130,7 +130,7 @@ def build_parser():
     parser = argparse.ArgumentParser()
 
     # add sample uuid
-    parser.add_argument('-U', '--uuid', required = True,
+    parser.add_argument('-U', '--uuid_manifest', required = True,
                         help = 'Sample UUID.')
 
     # what pipeline are we running
@@ -197,6 +197,27 @@ def build_parser():
     
     # return built parser
     return parser
+
+
+def sample_loop(job, bucket_region, s3_bucket, uuid_list, bwa_inputs, adam_inputs, gatk_preprocess_inputs, gatk_adam_call_inputs, gatk_gatk_call_inputs, pipeline_to_run):
+  """
+  Loops over the sample_ids (uuids) in the manifest, creating child jobs to process each
+  """
+
+  for uuid in uuid_list:
+
+    ## set uuid inputs
+    bwa_inputs['lb'] = uuid
+    bwa_inputs['uuid'] = uuid
+    adam_inputs['outDir'] = "s3://%s/analysis/%s" % (s3_bucket, uuid)
+    adam_inputs['bamName'] = "s3://%s/alignment/%s.bam" % (s3_bucket, uuid)
+    gatk_preprocess_inputs['s3_dir'] =  "%s/analysis/%s" % (s3_bucket, uuid)
+    gatk_adam_call_inputs['s3_dir'] = "%s/analysis/%s" % (s3_bucket, uuid)
+    gatk_gatk_call_inputs['s3_dir'] = "%s/analysis/%s" % (s3_bucket, uuid)
+
+    job.addChildJobFn(static_dag, bucket_region, s3_bucket, uuid, bwa_inputs, adam_inputs, gatk_preprocess_inputs, gatk_adam_call_inputs, gatk_gatk_call_inputs, pipeline_to_run )
+    
+  
 
 def static_dag(job, bucket_region, s3_bucket, uuid, bwa_inputs, adam_inputs, gatk_preprocess_inputs, gatk_adam_call_inputs, gatk_gatk_call_inputs, pipeline_to_run):
     """
@@ -275,9 +296,11 @@ def static_dag(job, bucket_region, s3_bucket, uuid, bwa_inputs, adam_inputs, gat
     gatk_gatk_call = job.wrapJobFn(batch_start,
                                    gatk_gatk_call_inputs).encapsulate()
 
+    
+
     # wire up dag
     job.addChild(bwa)
-    
+   
     if (pipeline_to_run == "adam" or
         pipeline_to_run == "both"):
         bwa.addChild(adam_preprocess)
@@ -287,6 +310,7 @@ def static_dag(job, bucket_region, s3_bucket, uuid, bwa_inputs, adam_inputs, gat
         pipeline_to_run == "both"):
         bwa.addChild(gatk_preprocess)
         gatk_preprocess.addChild(gatk_gatk_call)
+   
 
 if __name__ == '__main__':
     
@@ -294,6 +318,13 @@ if __name__ == '__main__':
     Job.Runner.addToilOptions(args_parser)
     args = args_parser.parse_args()
 
+    ## Parse manifest file
+    uuid_list = []
+    with open(args.uuid_manifest) as f_manifest:
+      for uuid in f_manifest:
+        uuid_list.append(uuid.strip())
+
+    
     bwa_inputs = {'ref.fa': args.ref,
                   'ref.fa.amb': args.amb,
                   'ref.fa.ann': args.ann,
@@ -306,8 +337,6 @@ if __name__ == '__main__':
                   'output_dir': None,
                   'sudo': args.sudo,
                   's3_dir': "%s/alignment" % args.s3_bucket,
-                  'lb': args.uuid,
-                  'uuid': args.uuid,
                   'cpu_count': None,
                   'file_size': args.file_size,
                   'use_bwakit': args.use_bwakit,
@@ -318,14 +347,12 @@ if __name__ == '__main__':
         raise ValueError("--num_nodes allocates one Spark/HDFS master and n-1 workers, and thus must be greater than 1. %d was passed." % args.num_nodes)
 
     adam_inputs = {'numWorkers': args.num_nodes - 1,
-                   'outDir':     's3://%s/analysis/%s' % (args.s3_bucket, args.uuid),
                    'knownSNPs':  args.dbsnp.replace("https://s3-us-west-2.amazonaws.com/", "s3://"),
                    'accessKey':  args.aws_access_key,
                    'secretKey':  args.aws_secret_key,
                    'driverMemory': args.driver_memory,
                    'executorMemory': args.executor_memory,
                    'sudo': args.sudo,
-                   'bamName': 's3://%s/alignment/%s.bam' % (args.s3_bucket, args.uuid),
                    'suffix': '.adam'}
 
     gatk_preprocess_inputs = {'ref.fa': args.ref,
@@ -336,8 +363,7 @@ if __name__ == '__main__':
                               'sudo': args.sudo,
                               'ssec': None,
                               'cpu_count': str(multiprocessing.cpu_count()),
-                              'suffix': '.gatk',
-                              's3_dir': "%s/analysis/%s" % (args.s3_bucket, args.uuid),}
+                              'suffix': '.gatk' }
     
     gatk_adam_call_inputs = {'ref.fa': args.ref,
                              'phase.vcf': args.phase,
@@ -349,7 +375,6 @@ if __name__ == '__main__':
                              'uuid': None,
                              'cpu_count': str(multiprocessing.cpu_count()),
                              'ssec': None,
-                             's3_dir': "%s/analysis/%s" % (args.s3_bucket, args.uuid),
                              'file_size': args.file_size,
                              'aws_access_key':  args.aws_access_key,
                              'aws_secret_key':  args.aws_secret_key,
@@ -365,7 +390,6 @@ if __name__ == '__main__':
                              'uuid': None,
                              'cpu_count': str(multiprocessing.cpu_count()),
                              'ssec': None,
-                             's3_dir': "%s/analysis/%s" % (args.s3_bucket, args.uuid),
                              'file_size': args.file_size,
                              'aws_access_key':  args.aws_access_key,
                              'aws_secret_key':  args.aws_secret_key,
@@ -376,10 +400,10 @@ if __name__ == '__main__':
         args.pipeline_to_run != "both"):
         raise ValueError("--pipeline_to_run must be either 'adam', 'gatk', or 'both'. %s was passed." % args.pipeline_to_run)
 
-    Job.Runner.startToil(Job.wrapJobFn(static_dag,
+    Job.Runner.startToil(Job.wrapJobFn(sample_loop,
                                        args.bucket_region,
                                        args.s3_bucket,
-                                       args.uuid,
+                                       uuid_list,
                                        bwa_inputs,
                                        adam_inputs,
                                        gatk_preprocess_inputs,

--- a/src/toil_scripts/adam_gatk_pipeline/call_vs_grch38.sh
+++ b/src/toil_scripts/adam_gatk_pipeline/call_vs_grch38.sh
@@ -10,10 +10,10 @@ set -x -v
 
 # swapped phase and mills --> pos error in #https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/ALL.wgs.1000G_phase3.GRCh38.ncbi_remapper.20150424.shapeit2_indels.vcf \
 python -m toil_scripts.adam_gatk_pipeline.align_and_call \
-    aws:us-west-2:fnothaft-toil-jobstore \
+    aws:us-west-2:paschall-toil-jobstore \
     --retryCount 1 \
-    --uuid SRR062643 \
-    --s3_bucket fnothaft-fc-test-west-2 \
+    --uuid_manifest my_manifest_file \
+    --s3_bucket paschall-fc-test-west-2 \
     --bucket_region us-west-2 \
     --aws_access_key ${FC_AWS_ACCESS_KEY_ID} \
     --aws_secret_key ${FC_AWS_SECRET_ACCESS_KEY} \

--- a/src/toil_scripts/adam_gatk_pipeline/my_manifest_file
+++ b/src/toil_scripts/adam_gatk_pipeline/my_manifest_file
@@ -1,0 +1,3 @@
+SRRtest1
+SRRtest2
+SRRtest3


### PR DESCRIPTION
This commit to process a multiple samples provided in a manifest appears to work properly through the running of bwa as the expected bam files for the three samples in the example `my_manifest_file` are generated.

However, it remains possible that the code in this commit introduces new errors when it passes on parameters   from this new  `sample_loop` function  to the existing `static_dag`.   More testing is needed as the remaining pipeline bugs are fixed.

I've been running this by placing the manifest file in the `src` dir and running like

```
src$ bash toil_scripts/adam_gatk_pipeline/call_vs_grch38.sh 
```

Also, sequential addition of child jobs turns out to be fine for hundreds of samples, we can look later at the tree fan out method when considering several thousand.
